### PR TITLE
Docs

### DIFF
--- a/docs/getting-started/installing-docksal/installation/_index.md
+++ b/docs/getting-started/installing-docksal/installation/_index.md
@@ -29,7 +29,7 @@ This runs Docker inside a Virtual Machine with VirtualBox.
 ### macOS with Docker for Mac
 
 1. Install Docker for Mac (a prerequisite)
-2. Start Docker for Mac and wait until the animation stops and/or the Docker menu says "Docker is running
+2. Start Docker for Mac and wait until the animation stops and/or the Docker menu says "Docker is running"
 3. Install Docksal by opening a terminal and running
 
     ``` bash

--- a/docs/getting-started/installing-docksal/prereqs/_index.md
+++ b/docs/getting-started/installing-docksal/prereqs/_index.md
@@ -17,7 +17,7 @@ The prerequisites for installing Docksal are pretty slim, but important.
 
 * ### Linux
   * By default, Apache listens on `0.0.0.0:80` and `0.0.0.0:443`. This will prevent Docksal reverse proxy from running properly. You can resolve it an any of the following ways:
-      * Reconfigure Apache to listen on different host (e.g., 1`27.0.0.1:80` and `127.0.0.1:443`)
+      * Reconfigure Apache to listen on different hosts (e.g., 1`27.0.0.1:80` and `127.0.0.1:443`)
       * Reconfigure Apache to listen on different ports (e.g., `8080` and `4433`)
       * Stop and disable Apache
 

--- a/docs/getting-started/installing-drupal/_index.md
+++ b/docs/getting-started/installing-drupal/_index.md
@@ -27,7 +27,7 @@ Here we're pulling the repo and checking out the Step 1 branch, where we're goin
 **NOTE:** There is a possibility that the default settings may not provision enough memory or CPU power in your virtual machine for some steps of the next section. If your build fails, then consult the [Troubleshooting](#troubleshooting) portion of this section.
 {{% /notice %}}
 
-Now that we've cloned the repo we're going to run a command we haven't talked about yet: `fin init`
+Now that we've cloned the repo, we're going to run a command we haven't talked about yet: `fin init`
 
 Before we run that, a little info on what `fin init` is and what it does. `fin init` is a custom command that is not part of the core Docksal package. Instead, it is customized on a project by project basis, and sometimes is not required. The purpose of `fin init` is usually to completely start or restart a project from a clean state.
 
@@ -57,7 +57,7 @@ Volume docksal_ssh_agent is external, skipping
 
 The `WARNING:` lines let us know that the project does not already exist, but it also points out that we're attempting to remove the current containers as part of the `fin init` process.
 
-If all runs according to plan you will see Composer do some things, Docksal do some things, and Drupal do some things, eventually ending with
+If all runs according to plan you will see Composer do some things, Docksal do some things, and Drupal do some things, eventually ending with:
 
 ``` bash
 [notice] Starting Drupal installation. This takes a while.
@@ -156,10 +156,10 @@ Check https://getcomposer.org/doc/articles/troubleshooting.md#proc-open-fork-fai
 
 That means you'll need to add some resources to your virtual machine.
 
-1. Run `fin system stop` to shut down the VM.
-2. Open your VirtualBox application.
-3. Highlight the `docksal` machine, making sure it is in a `Powered off` state.
-4. Select "Settings".
+1. Run `fin system stop` to shut down the VM
+2. Open your VirtualBox application
+3. Highlight the `docksal` machine, making sure it is in a `Powered off` state
+4. Select "Settings"
 5. Under "System > Motherboard" increase the memory to 4096 MB
 6. Under "System > Processor" increase the CPUs to 4
 7. Go back to your terminal and run `fin system start`

--- a/docs/getting-started/new-project/_index.md
+++ b/docs/getting-started/new-project/_index.md
@@ -32,28 +32,35 @@ We're going to begin by entering our terminal and going to a project folder. For
     ``` bash
     1. What would you like to install?
       PHP based
-        1.  Drupal 8
-        2.  Drupal 8 (Composer Version)
-        3.  Drupal 7
-        4.  Wordpress
-        5.  Magento
-        6.  Laravel
-        7.  Symfony Skeleton
-        8.  Symfony WebApp
-        9.  Grav CMS
-        10. Backdrop CMS
+        1.  Drupal 9 (Composer Version)
+        2.  Drupal 9 (BLT Version)
+        3.  Drupal 9
+        4.  Drupal 8
+        5.  Drupal 8 (Composer Version)
+        6.  Drupal 8 (BLT Version)
+        7.  Drupal 7
+        8.  Wordpress
+        9.  Magento
+        10.  Laravel
+        11.  Symfony Skeleton
+        12.  Symfony WebApp
+        13. Grav CMS
+        14. Backdrop CMS
 
       Go based
-        11.  Hugo
+        15.  Hugo
 
       JS based
-        12.  Gatsby JS
-        13.  Angular
+        16.  Gatsby JS
+        17.  Angular
 
       HTML
-        14.  Static HTML site
+        18.  Static HTML site
 
-    Enter your choice (1-14): 14
+      Custom
+        0. Custom git repository
+
+    Enter your choice (0-18): 18
     ```
 
 4. Next, we'll be able to verify our setup with the following prompt:

--- a/docs/going-further/addons/_index.md
+++ b/docs/going-further/addons/_index.md
@@ -17,6 +17,7 @@ We touched on creating your own commands in [Advanced Customizations: Project 3]
 |   blt | Acquia BLT tool launcher (requires [BLT installation](https://blog.docksal.io/docksal-and-acquia-blt-1552540a3b9f)) | Drupal |
 |   codeclimate | [CodeClimate](https://codeclimate.com/) code quality tool | |
 |   mailhog | [Mailhog](https://github.com/mailhog/MailHog) e-mail capture service for current project |  |
+|   mkcert | [mkcert](https://github.com/FiloSottile/mkcert) addon for Docksal |  |
 |   phpcs | PHP Code Sniffer and Code Beautifier | |
 |   phpunit | Creates a phpunit.xml file and runs PHPUnit tests | Drupal |
 |   pma | [PhpMyAdmin](https://www.phpmyadmin.net/) database management tool | MySQL |
@@ -24,7 +25,9 @@ We touched on creating your own commands in [Advanced Customizations: Project 3]
 |   sequelpro | Launches [SequelPro](https://www.sequelpro.com) with the connection information for current project. | macOS |
 |   simpletest | Runs SimpleTest tests in Drupal 7 and 8 | Drupal |
 |   solr | [Apache Solr](http://lucene.apache.org/solr/) search service for current project |  |
+|   tableplus | Launches [TablePlus](https://www.tableplus.com) with the connection information for current project. | macOS |
 |   uli | Generate one time login url for current site | Drupal |
+|   wkhtmltopdf | Installs wkhtmltopdf 0.12.5 with QT compiled in. |  |
 
 All of these are available to install and use to make development a little quicker and easier. Let's install an addon.
 

--- a/docs/going-further/advanced-customizing/project-1.md
+++ b/docs/going-further/advanced-customizing/project-1.md
@@ -9,7 +9,7 @@ weight: 8
 For this project, we're going to use the following scenario:
 
 {{% notice info %}}
-Your client has a site on Acquia using PHP 7.3. You know that the default Docksal Acquia stack uses PHP 7.2, but you want to match environments. How do you do this?
+Your client has a site on Acquia using PHP 7.4. You know that the default Docksal Acquia stack uses PHP 7.3, but you want to match environments. How do you do this?
 {{% /notice %}}
 
 ### Choose the right stack
@@ -28,15 +28,15 @@ In `composer.json`, in the `extra.installer-paths` section, you need to change a
 
 ### Configure the PHP version
 
-The PHP version is defined in the `cli` service. The default image for the `cli` service is `docksal/cli:2.6-php7.2`. We can change this in `docksal.env` by adding the following variable: `CLI_IMAGE=docksal/cli:2.9-php7.3`. This is the latest version of this image tagged with PHP 7.3.
+The PHP version is defined in the `cli` service. The default image for the `cli` service is `docksal/cli:2.11-php7.3`. We can change this in `docksal.env` by adding the following variable: `CLI_IMAGE=docksal/cli:2.11-php7.4`. This is the latest version of this image tagged with PHP 7.4.
 
-Inside `~/.docksal/stacks/services.yml` the `cli` section runs logic for the image version: `image: ${CLI_IMAGE:-docksal/cli:2.6-php7.2}` which checks to see if the `CLI_IMAGE` environment variable is set, and if not, uses the default.
+Inside `~/.docksal/stacks/services.yml` the `cli` section runs logic for the image version: `image: ${CLI_IMAGE:-docksal/cli:2.11-php7.3}` which checks to see if the `CLI_IMAGE` environment variable is set, and if not, uses the default.
 
 ### Update your project
 
 The easiest way to do this is to run `fin up`, however if you have not initialized your project yet, you should run `fin init`. For this exercise we're going to run `fin init`.
 
-Run `fin init` and watch as the images that aren't on your system are pulled down and your project spins up using PHP 7.3.x.
+Run `fin init` and watch as the images that aren't on your system are pulled down and your project spins up using PHP 7.4.x.
 
 {{% notice tip %}}
 The completed code for Project 1 can be found at https://github.com/JDDoesDev/docksal-training-projects/tree/adv-cust-project-1

--- a/docs/going-further/advanced-customizing/project-2.md
+++ b/docs/going-further/advanced-customizing/project-2.md
@@ -21,7 +21,7 @@ We're going to create a custom Dockerfile that extends the default `cli` image w
 2. Extend the current image by starting the file with
 
     ``` dockerfile
-    FROM docksal/cli:2.9-php7.3
+    FROM docksal/cli:2.11-php7.3
     ```
 
     This tells Docksal that we're still going to use this image, but we're doing something more with it.
@@ -66,7 +66,7 @@ We're going to create a custom Dockerfile that extends the default `cli` image w
       Our completed Dockerfile should look like this
 
       ```dockerfile
-      FROM docksal/cli:2.9-php7.3
+      FROM docksal/cli:2.11-php7.3
 
       USER docker
 

--- a/docs/going-further/advanced-customizing/project-3.md
+++ b/docs/going-further/advanced-customizing/project-3.md
@@ -37,7 +37,7 @@ To do this we're going to use both a custom Dockerfile and edit our `docksal.yml
 2. We're going to extend the default Docksal CLI image so start the file with:
 
     ```dockerfile
-    FROM docksal/cli:2.9-php7.3
+    FROM docksal/cli:2.11-php7.3
     ```
 
 3. We want to run all of our installations as our default container user "docker" so we need to make sure to switch users in the Dockerfile.
@@ -94,7 +94,7 @@ To do this we're going to use both a custom Dockerfile and edit our `docksal.yml
 The final Dockerfile should look like this:
 
 ``` dockerfile
-FROM docksal/cli:2.9-php7.3
+FROM docksal/cli:2.11-php7.3
 
 USER docker
 

--- a/docs/going-further/advanced-customizing/project-3.md
+++ b/docs/going-further/advanced-customizing/project-3.md
@@ -13,7 +13,7 @@ A client wants a decoupled solution to be hosted on two servers. The Drupal side
 
 Now, we can build off our last step by continuing to grow our `docksal.yml` and `docksal.env` files. We're also going to add in some custom commands to make our life a little bit easier in the long run.
 
-Let's start off by listing what we're going to needing for this project:
+Let's start off by listing what we're going to need for this project:
 
 * A Drupal installation on an Acquia Stack
 * Multiple domains

--- a/docs/going-further/keep-it-local/_index.md
+++ b/docs/going-further/keep-it-local/_index.md
@@ -120,12 +120,12 @@ This file is not read by Docksal, does not keep any sensitive data, and can be k
 You could do the same with an `example.docksal-local.yml` file as well.
 
 ``` yaml
-## To test the codebase against PHP 7.3, copy this file to docksal-local.yml and
+## To test the codebase against PHP 7.4, copy this file to docksal-local.yml and
 ## restart your project.
 version: "2.1"
 services:
   cli:
-    image: "docksal/cli:2.9-php7.3"
+    image: "docksal/cli:2.11-php7.4"
 ```
 
 ### Summary

--- a/docs/intro-docker/docker-basics/docker-components/client/_index.md
+++ b/docs/intro-docker/docker-basics/docker-components/client/_index.md
@@ -5,6 +5,6 @@ weight: 1
 
 ## Docker client
 
-The Docker client is responsible for everything that containers do. There are a Docker clients available for most common operating systems, including macOS, Windows, and most, if not all Linux distributions. The Docker client can either be on the same host as the daemon, or long-running program, or it can connect to a remote daemon. It also provides the CLI, or command line interface, to start, stop, build, and execute commands within containers.
+The Docker client is responsible for everything that containers do. There are Docker clients available for most common operating systems, including macOS, Windows, and most, if not all Linux distributions. The Docker client can either be on the same host as the daemon, or long-running program, or it can connect to a remote daemon. It also provides the CLI, or command line interface, to start, stop, build, and execute commands within containers.
 
 The Docker client is mainly used for pulling images and running them on the host.

--- a/docs/intro-docker/docker-basics/docker-components/registries/_index.md
+++ b/docs/intro-docker/docker-basics/docker-components/registries/_index.md
@@ -11,4 +11,4 @@ A registry is where images are stored. The most common of these is [Docker Hub](
 **NOTE:** The trainers do not condone the hunting of whales for the making of whale sausage. Whales are beautiful, endangered creatures.
 {{% /notice %}}
 
-It is possible to add custom registries or even private registries to your Docker setup, but that is outside the scope of this training. Please consult the [Docker docs](http://docs.docker.com)
+It is possible to add custom registries or even private registries to your Docker setup, but that is outside the scope of this training. Please consult the [Docker docs](http://docs.docker.com).

--- a/docs/intro-docker/docker-basics/docker-components/services/_index.md
+++ b/docs/intro-docker/docker-basics/docker-components/services/_index.md
@@ -11,8 +11,8 @@ Services are often part of a larger application whereas containers usually stand
 
 Many of the functions of services are beyond the scope of this section of the training, however a few things that should be noted are:
 
-* Docker services are defined individually as part of a larger application.
+* Docker services are defined individually as part of a larger application
 * Docker services are structured in Dockerfiles, however they are managed by `docker-compose`, a utility that interacts with an entire application rather than a single container
-* Applications that use services are defined in a `*.yml` file, often named `docker-compose.yml` with several services defined along with settings and information to help everything run together.
+* Applications that use services are defined in a `*.yml` file, often named `docker-compose.yml` with several services defined along with settings and information to help everything run together
 
 The [Docker docs](https://docs.docker.com) have many examples of using services and it's something that we will cover more in the Configuring Docksal section later.

--- a/docs/intro-docker/docker-basics/docker-components/storage/bind-mounts/_index.md
+++ b/docs/intro-docker/docker-basics/docker-components/storage/bind-mounts/_index.md
@@ -140,7 +140,7 @@ Testing a bind mount
 And now I'm changed from the host
 ```
 
-Outstanding! We now have the ability to change files in the container from our host which means that we can develop on our host and use the power of containers to build and host our code in a repeatable manner.
+Outstanding! We now have the ability to change files in the container from our host, which means that we can develop on our host and use the power of containers to build and host our code in a repeatable manner.
 
 There are a lot more feature of bind mounts and other mounts that are beyond the scope of this training. For further reading please check out the [Docker Docks](https://docs.docker.com/storage/bind-mounts/).
 

--- a/docs/intro-docksal/in-the-container/_index.md
+++ b/docs/intro-docksal/in-the-container/_index.md
@@ -13,7 +13,7 @@ As briefly mentioned in a previous section, Docksal ships with many developer to
 * Composer - a tool for managing PHP packages
 * Drupal Console - a Drupal CLI tool
 * Drush - a Drupal CLI tool
-* Acquia Drush Commands - custom Drush commands to work with Acquia
+* Acquia CLI - tool for using Acquia Cloud API v2 on the command line
 * ngrok - a utility for sharing local applications over the internet
 * PHP Code Sniffer - a PHP linting and error checking tool
 * PHPMyAdmin - a web-based GUI for interacting with databases
@@ -22,6 +22,7 @@ As briefly mentioned in a previous section, Docksal ships with many developer to
 * SASS and Compass - tools for compiling SASS
 * WP-CLI - a CLI tool for interacting with WordPress sites
 * Xdebug - a PHP debugging utility
+* Xhprof - tool to profile your PHP application
 
 ### Others are available as services
 

--- a/docs/intro-docksal/services/_index.md
+++ b/docs/intro-docksal/services/_index.md
@@ -25,13 +25,13 @@ The default stack contains these project services:
 
     The default `cli` service runs `supervisord`. This is a client/server system that Docksal uses to control processes on the service. For `cli` these processes are the daemons `php-fpm`, which we use for running our PHP scripts, `crond`, which executes scheduled commands, and `sshd`, which is used to allow SSH connections.
 
-    It uses the `docksal/cli:2.6-php7.2` image out of the box which contains PHP 7.2, Composer, Drush, Drupal Console, WP-CLI, Terminus, and Platform along with many more. It also has Nodejs v10.15.0, Ruby 2.6.0, Python 2.7.0, and msmtp. These inclusions are useful for having some of the most commonly used languages and compilers/interpreters used in web application development.
+    It uses the `docksal/cli:2.11-php7.3` image out of the box which contains PHP 7.3, Composer, Drush, Drupal Console, WP-CLI, Terminus, and Platform along with many more. It also has Nodejs v12.18.1, Ruby 2.7.1, Python 3.8.3, and msmtp. These inclusions are useful for having some of the most commonly used languages and compilers/interpreters used in web application development.
 
 * `db`
 
     The default `db` service runs the `mysqld` daemon. This allows connections to the database layer and separates the database layer from the CLI layer to simulate a real hosting environment.
 
-    It uses the `docksal/mysql:5.6-1.4` image out of the box with MySQL 5.6.
+    It uses the `docksal/mysql:5.6-1.5` image out of the box with MySQL 5.6.
 
 * `web`
 

--- a/docs/intro-docksal/starter-kits/_index.md
+++ b/docs/intro-docksal/starter-kits/_index.md
@@ -13,6 +13,7 @@ As noted in the ["What's Docksal?"](/docs/intro-docksal/whats-docksal/) section,
 
 They are:
 
+* Drupal 9
 * Drupal 8
 * Drupal 7
 * Wordpress

--- a/docs/intro-docksal/whats-docksal/_index.md
+++ b/docs/intro-docksal/whats-docksal/_index.md
@@ -21,6 +21,7 @@ Over time it's grown into a powerful, robust, and highly configurable developmen
 
 Docksal is currently used by several agencies and development shops as a tool to speed up development, test code rapidly, and deploy with ease. It's become one of the top developer tools, including out of the box support for:
 
+* Drupal 9
 * Drupal 8
 * Drupal 7
 * Wordpress

--- a/docs/introduction/about/_index.md
+++ b/docs/introduction/about/_index.md
@@ -22,7 +22,7 @@ This training is designed based on the [Docksal Docs](https://docs.docksal.io) w
   * Docksal System and Default Services
       * We're going to explore some of the services that come with Docksal and where they're used.
   * Boilerplates and Starterkits
-      * It's not just for Drupal! Let's explore a few of the available boilerplate projects that are in the Docksal Github Repo
+      * It's not just for Drupal! Let's explore a few of the available boilerplate projects that are in the Docksal Github Repo.
   * What's in the Container?
       * We're going to explore some of the tools that are included with Docksal straight out of the box. Many should feel very familiar.
 * GETTING STARTED


### PR DESCRIPTION
In this PR there are typo fixes, version corrections, tool additions, etc.

A few other notes:

- There isn't anywhere stating that NFS is now the default for Docker native mode, which is much faster than bind mount.
- This line (line 300 in `docs/going-further-advanced-customzing/project-3.md`):
>run fin project start because fin up may not capture all of your changes

This isn't the case. The help output states that fin up "Configuration re-read and start project services." The commands are identical except that up resets some environment variables to force the re-read.
This is also in line 79 of `docs/going-further/keep-it-local/_index.md`
- There are a couple of links to `placeholder`
docs/intro-docksal/services/_index.md
docs/intro-docksal/stacks/_index.md